### PR TITLE
remove sudo in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-sudo: required
+sudo: false
 before_install:
   - wget https://raw.githubusercontent.com/y-yu/install-tex-travis/master/install-tex.sh
   - wget https://raw.githubusercontent.com/y-yu/install-tex-travis/master/tlmgr.sh


### PR DESCRIPTION
In this TeX Live installing script to Travis CI, you don't need to use `sudo`. So I remove it.

### Sample Result

https://travis-ci.org/y-yu/Gotoh/builds/229611506

### P.S

Thank you for using my install script!